### PR TITLE
Fix balance summary on main page

### DIFF
--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -152,7 +152,7 @@ export function sumMonthlyBalances(
   accountSummaries.forEach((summary) => {
     summary.monthlyBalances.monthlyBalances.forEach((balance) => {
       if (
-        balance.yearMonth >= startYearMonth &&
+        balance.yearMonth > startYearMonth &&
         balance.yearMonth <= endYearMonth
       ) {
         totalBalance += parseFloat(balance.monthlyBalance);


### PR DESCRIPTION
When summing the main balances graph start summing from the 2nd month only, so that the starting point is 0.

This PR fixes issue https://github.com/isaacnorman82/finances/issues/37